### PR TITLE
MicroG Extended support

### DIFF
--- a/.env
+++ b/.env
@@ -10,7 +10,7 @@ EXISTING_DOWNLOADED_APKS=reddit_sync,MicroG
 # ALTERNATIVE_YOUTUBE_PATCHES=custom-branding-icon-afn-blue,custom-branding-icon-revancify-blue,custom-branding-icon-mmt
 #
 #
-BUILD_EXTENDED=True
+BUILD_EXTENDED=False
 # <ext>True</ext>
 #
 # YOUTUBE_VERSION=latest_supported

--- a/.env
+++ b/.env
@@ -1,8 +1,7 @@
 # <>
 KEYSTORE_FILE_NAME=revanced.keystore
 ARCHS_TO_BUILD=arm64-v8a
-PATCH_APPS=MicroG
-# PATCH_APPS=youtube,youtube_music,reddit,reddit_sync,trakt
+PATCH_APPS=youtube,youtube_music,reddit,reddit_sync,trakt,MicroG
 REDDIT_VERSION=latest
 TRAKT_VERSION=latest
 EXISTING_DOWNLOADED_APKS=reddit_sync,MicroG

--- a/.env
+++ b/.env
@@ -9,7 +9,7 @@ EXISTING_DOWNLOADED_APKS=reddit_sync,MicroG
 # ALTERNATIVE_YOUTUBE_PATCHES=custom-branding-icon-afn-blue,custom-branding-icon-revancify-blue,custom-branding-icon-mmt
 #
 #
-BUILD_EXTENDED=False
+BUILD_EXTENDED=True
 # <ext>True</ext>
 #
 # YOUTUBE_VERSION=latest_supported

--- a/.env
+++ b/.env
@@ -1,7 +1,8 @@
 # <>
 KEYSTORE_FILE_NAME=revanced.keystore
 ARCHS_TO_BUILD=arm64-v8a
-PATCH_APPS=youtube,youtube_music,reddit,reddit_sync,trakt
+PATCH_APPS=MicroG
+# PATCH_APPS=youtube,youtube_music,reddit,reddit_sync,trakt
 REDDIT_VERSION=latest
 TRAKT_VERSION=latest
 EXISTING_DOWNLOADED_APKS=reddit_sync

--- a/.env
+++ b/.env
@@ -5,7 +5,7 @@ PATCH_APPS=MicroG
 # PATCH_APPS=youtube,youtube_music,reddit,reddit_sync,trakt
 REDDIT_VERSION=latest
 TRAKT_VERSION=latest
-EXISTING_DOWNLOADED_APKS=reddit_sync
+EXISTING_DOWNLOADED_APKS=reddit_sync,MicroG
 # ALTERNATIVE_YOUTUBE_MUSIC_PATCHES=custom-branding-music-afn-red,custom-branding-music-revancify-blue,custom-branding-music-mmt
 # ALTERNATIVE_YOUTUBE_PATCHES=custom-branding-icon-afn-blue,custom-branding-icon-revancify-blue,custom-branding-icon-mmt
 #

--- a/src/config.py
+++ b/src/config.py
@@ -32,7 +32,7 @@ class RevancedConfig(object):
         self.keystore_name = env.str("KEYSTORE_FILE_NAME", "revanced.keystore")
         self.ci_test = env.bool("CI_TEST", False)
         self.apps = env.list("PATCH_APPS", default_build)
-        self.extended_apps: List[str] = ["youtube", "youtube_music"]
+        self.extended_apps: List[str] = ["youtube", "youtube_music", "MicroG"]
         self.rip_libs_apps: List[str] = ["youtube"]
         self.normal_cli_jar = "revanced-cli.jar"
         self.normal_patches_jar = "revanced-patches.jar"

--- a/src/downloader/download.py
+++ b/src/downloader/download.py
@@ -138,7 +138,7 @@ class Downloader(object):
             ]
         if "youtube" in self.config.apps or "youtube_music" in self.config.apps:
             assets += [
-                ["inotia00", "mMicroG", "mMicroG-output.apk"],
+                ["inotia00", "mMicroG", "MicroG.apk"],
             ]
         with ThreadPoolExecutor(7) as executor:
             executor.map(lambda repo: self.repository(*repo), assets)

--- a/src/downloader/download.py
+++ b/src/downloader/download.py
@@ -136,7 +136,7 @@ class Downloader(object):
                 ["inotia00", "revanced-integrations", self.config.integrations_apk],
                 ["inotia00", "revanced-patches", self.config.patches_jar],
             ]
-        if "youtube" in self.config.apps or "youtube_music" in self.config.apps:
+        if "youtube" in self.config.apps or "youtube_music" in self.config.apps or "MicroG" in self.config.apps:
             assets += [
                 ["inotia00", "mMicroG", "MicroG.apk"],
             ]

--- a/src/downloader/download.py
+++ b/src/downloader/download.py
@@ -136,7 +136,7 @@ class Downloader(object):
                 ["inotia00", "revanced-integrations", self.config.integrations_apk],
                 ["inotia00", "revanced-patches", self.config.patches_jar],
             ]
-        if "youtube" in self.config.apps or "youtube_music" in self.config.apps:
+        if "youtube" in self.config.apps or "youtube_music" in self.config.apps or "MicroG" in self.config.apps:
             if self.config.build_extended and "MicroG" in self.config.apps:
                 assets += [
                     ["inotia00", "mMicroG", "MicroG.apk"],

--- a/src/downloader/download.py
+++ b/src/downloader/download.py
@@ -143,7 +143,7 @@ class Downloader(object):
                 ]
             else:
                 assets += [
-                    ["inotia00", "mMicroG", "mMicroG.apk"],
+                    ["inotia00", "mMicroG", "mMicroG-output.apk"],
                 ]
         with ThreadPoolExecutor(7) as executor:
             executor.map(lambda repo: self.repository(*repo), assets)

--- a/src/downloader/download.py
+++ b/src/downloader/download.py
@@ -136,10 +136,15 @@ class Downloader(object):
                 ["inotia00", "revanced-integrations", self.config.integrations_apk],
                 ["inotia00", "revanced-patches", self.config.patches_jar],
             ]
-        if "youtube" in self.config.apps or "youtube_music" in self.config.apps or "MicroG" in self.config.apps:
-            assets += [
-                ["inotia00", "mMicroG", "MicroG.apk"],
-            ]
+        if "youtube" in self.config.apps or "youtube_music" in self.config.apps:
+            if self.config.build_extended and "MicroG" in self.config.apps:
+                assets += [
+                    ["inotia00", "mMicroG", "MicroG.apk"],
+                ]
+            else:
+                assets += [
+                    ["inotia00", "mMicroG", "mMicroG.apk"],
+                ]
         with ThreadPoolExecutor(7) as executor:
             executor.map(lambda repo: self.repository(*repo), assets)
         logger.info("Downloaded revanced microG ,cli, integrations and patches.")

--- a/src/patches.py
+++ b/src/patches.py
@@ -55,6 +55,7 @@ class Patches(object):
     _revanced_extended_app_ids = {
         "com.google.android.youtube": ("youtube", "_yt"),
         "com.google.android.apps.youtube.music": ("youtube_music", "_ytm"),
+        "com.mgoogle.android.gms": ("MicroG", "_MicroG")
     }
     revanced_extended_app_ids = {
         key: (value[0], "_" + value[0])


### PR DESCRIPTION
To patch MicroG (mMicroG, VancedMicroG), the user needs to 

1. Enter it's code (`MicroG`) in `PATCH_APPS` to patch.
2. Enter it's code (`MicroG`) as it'll be already downloaded and exist in `apks/` directory.
3. `BUILD_EXTENDED` must be set to `True`, as it requires inotia00's set of patches.

I've used to patch mMicroG but it could also patch VancedMicroG both provided by TeamVanced and inotia00.

```py
["inotia00", "mMicroG", "MicroG.apk"] # PATCH_APP_CODE=MicroG
```
The format above is 

```py
["REPO_OWNER", "REPO_NAME", "FILE_NAME.apk"]

# Examples:
["TeamVanced", "VancedMicroG", "TV-VMicroG.apk"] # PATCH_APP_CODE=TV-VMicroG
["inotia00", "VancedMicroG", "inotia00-VMicroG.apk"] # PATCH_APP_CODE=inotia00-VMicroG
```
See `download.py` or `downloader.py`. 

Also, make sure the file name (excluding extension) matches the code. The app code (not script code) needs to replicated as other patch apps in `config.py` and `patches.py`.

```py
if "youtube" in self.config.apps or "youtube_music" in self.config.apps or "MicroG" in self.config.apps:
            if self.config.build_extended and "MicroG" in self.config.apps:
                assets += [
                    ["inotia00", "mMicroG", "MicroG.apk"],
                ]
            else:
                assets += [
                    ["inotia00", "mMicroG", "mMicroG-output.apk"],
                ]
```
The above code in `download.py` or `downloader.py` means, that when patcher tries to build `youtube`, `youtube_music` or `MicroG` and if `BUILD_EXTENDED=True` and `MicroG` will be built then, download `inotia00's mMicroG -> rename as MicroG.apk` (patched later on). Else, it simply downloades `inotia00's mMicroG -> rename as mMicroG-output.apk` (unpatched). Similarly, the earlier code could be understood as well. 