### PR TITLE
⏳ Wait in APKM Requests

### DIFF
--- a/src/downloader/apkmirror.py
+++ b/src/downloader/apkmirror.py
@@ -1,4 +1,5 @@
 """Downloader Class."""
+import time
 from typing import Any, Self
 
 import requests
@@ -76,6 +77,8 @@ class ApkMirror(Downloader):
     @staticmethod
     def _extracted_search_div(url: str, search_class: str) -> Tag:
         """Extract search div."""
+        logger.info("Pausing for 15 seconds...")
+        time.sleep(15)
         r = requests.get(url, headers=request_header, timeout=request_timeout)
         handle_request_response(r, url)
         soup = BeautifulSoup(r.text, bs4_parser)


### PR DESCRIPTION
This somehow fixes **APKMirror Bot protection** (#375) issue which is triggered from 6th app onwards. The pause period is of 15 seconds and any lower than that failed. 
Also, tried using selenium but it gave huge delays (24m) in a single request, which is highly inconvenient.

Although, this can introduce slight delays in cooking the build.